### PR TITLE
updated instances url

### DIFF
--- a/ibm_vpc/vpc_v1.py
+++ b/ibm_vpc/vpc_v1.py
@@ -3809,7 +3809,7 @@ class VpcV1(BaseService):
             headers.update(kwargs.get('headers'))
         headers['Accept'] = 'application/json'
 
-        url = '/instances'
+        url = '/instances?generation=2&version=2021-08-17'
         request = self.prepare_request(method='POST',
                                        url=url,
                                        headers=headers,


### PR DESCRIPTION
Currently, create request fails if boot volume size specified differs from 100.
After some debugging and comparing headers with ibmcloud cli it appears that create request has different url.
Updating it to the one used in ibmcloud cli resolves the issue. 