### PR TITLE
feat(2023-02-14): Update SDK to use API generated on 2023-02-14 and semantic release fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script: tox
 
 before_deploy:
 - pip install bump2version
-- nvm install v14.17.0
+- nvm install --lts
 - npm install @semantic-release/changelog
 - npm install @semantic-release/exec
 - npm install @semantic-release/git


### PR DESCRIPTION
semantic release fix
As per https://github.com/semantic-release/semantic-release/releases/tag/v20.0.0
and https://github.com/semantic-release/semantic-release/commit/c7b8e10bd1960969e9ebe6ee2dd6c7375363718a

semantic-release now needs node v18 as the minimum required version.

updating the nvm command to `nvm install --lts`  to always install the _latest_ time term support version