### PR TITLE
feat(2023-02-14): Update SDK to use API generated on 2023-02-14 and semantic release fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-dist: xenial
+dist: focal
 
 cache: pip
 


### PR DESCRIPTION
semantic release fix
As per https://github.com/semantic-release/semantic-release/releases/tag/v20.0.0
and https://github.com/semantic-release/semantic-release/commit/c7b8e10bd1960969e9ebe6ee2dd6c7375363718a

semantic-release now needs node v18 as the minimum required version.

updating the nvm command to nvm install --lts to always install the latest time term support version

distro upgraded from xeniel to focus to support node 18